### PR TITLE
feat: add support for discord embeds

### DIFF
--- a/src/main/java/me/roinujnosde/titansbattle/hooks/discord/DiscordWebhook.java
+++ b/src/main/java/me/roinujnosde/titansbattle/hooks/discord/DiscordWebhook.java
@@ -2,6 +2,7 @@ package me.roinujnosde.titansbattle.hooks.discord;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.IOException;
@@ -30,26 +31,26 @@ public class DiscordWebhook {
     }
 
     public void execute() throws IOException {
-        JsonObject json = new JsonObject();
+        JsonObject json;
 
-        if (content.contains("embeds")) {
-            JsonParser parser = new JsonParser();
-            json = parser.parse(content).getAsJsonObject();
-        } else {
+        try {
+            json = JsonParser.parseString(content).getAsJsonObject();
+        } catch (JsonSyntaxException e) {
+            json = new JsonObject();
             json.addProperty("content", content);
         }
 
         URL url = new URL(this.url);
         HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+        connection.setRequestMethod("POST");
         connection.addRequestProperty("Content-Type", "application/json");
         connection.addRequestProperty("User-Agent", "TitansBattle");
         connection.setDoOutput(true);
-        connection.setRequestMethod("POST");
 
-        OutputStream stream = connection.getOutputStream();
-        stream.write(json.toString().getBytes());
-        stream.flush();
-        stream.close();
+        try (OutputStream outputStream = connection.getOutputStream()) {
+            outputStream.write(json.toString().getBytes());
+            outputStream.flush();
+        }
 
         connection.getInputStream().close();
         connection.disconnect();


### PR DESCRIPTION
Open PR to address embeds support and at the same time content-only support (the only way currently)

One problem with embed support is the complexity of an embed: 

Complex embed in language.yml: 
```yml
discord_game_starting: |
'{'"content":"Teste Content","embeds":['{'"title":"Test Embed Body Title","description":"Test Embed Body Description","color":16711680,"fields":['{'"name":"Test Embed Field 1 Name","value":"Test Embed Field 1 Value"'}'],"author":'{'"name":"Test Embed Author"'}',"footer":'{'"text":"Test Footer"'}''}'],"username":"Teste Username","attachments":[],"thread_name":"Teste"'}'
```
Test embed:
![image](https://github.com/RoinujNosde/TitansBattle/assets/51332006/8849e047-aea0-4e12-a6d4-24c98c87e574)
