### PR TITLE
Correção de kits com novo formato NBT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.9.4-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.13.1-SNAPSHOT</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.6-R0.1-SNAPSHOT</version>
+            <version>1.9.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>net.sacredlabyrinth.phaed.simpleclans</groupId>

--- a/src/main/java/me/roinujnosde/titansbattle/types/Kit.java
+++ b/src/main/java/me/roinujnosde/titansbattle/types/Kit.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 
 @SerializableAs("kit")
 public class Kit implements ConfigurationSerializable {
@@ -141,10 +142,7 @@ public class Kit implements ConfigurationSerializable {
     }
 
     private void applyNBTTag(ItemStack item) {
-        NBT.modify(item, (ReadWriteItemNBT nbt) -> {
-            nbt.setBoolean(NBT_TAG, true);
-            return null;
-    });
+        NBT.modify(item, (Consumer<ReadWriteItemNBT>) nbtItem -> nbtItem.setBoolean(NBT_TAG, true));
     }
 
     private ItemStack clone(ItemStack item) {

--- a/src/main/java/me/roinujnosde/titansbattle/types/Kit.java
+++ b/src/main/java/me/roinujnosde/titansbattle/types/Kit.java
@@ -1,6 +1,8 @@
 package me.roinujnosde.titansbattle.types;
 
-import de.tr7zw.changeme.nbtapi.NBTItem;
+import de.tr7zw.changeme.nbtapi.NBT;
+import de.tr7zw.changeme.nbtapi.iface.ReadWriteItemNBT;
+
 import org.bukkit.Material;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.configuration.serialization.SerializableAs;
@@ -138,10 +140,17 @@ public class Kit implements ConfigurationSerializable {
         return clone((ItemStack) object);
     }
 
+    private void applyNBTTag(ItemStack item) {
+        NBT.modify(item, (ReadWriteItemNBT nbt) -> {
+            nbt.setBoolean(NBT_TAG, true);
+            return null;
+    });
+    }
+
     private ItemStack clone(ItemStack item) {
         if (item != null && item.getType() != Material.AIR) {
             item = item.clone();
-            new NBTItem(item, true).setBoolean(NBT_TAG, true);
+            applyNBTTag(item);
         }
         return item;
     }
@@ -149,7 +158,7 @@ public class Kit implements ConfigurationSerializable {
     private void setNBTTag(ItemStack[] items) {
         for (ItemStack item : items) {
             if (item != null && item.getType() != Material.AIR) {
-                new NBTItem(item, true).setBoolean(NBT_TAG, true);
+                applyNBTTag(item);
             }
         }
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ main: "me.roinujnosde.titansbattle.TitansBattle"
 name: "TitansBattle"
 author: "RoinujNosde"
 version: "${project.version}-${git.commit.id.describe-short}"
-api-version: 1.13
+api-version: 1.21
 softdepend:
   - "SimpleClans"
   - "Factions"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ main: "me.roinujnosde.titansbattle.TitansBattle"
 name: "TitansBattle"
 author: "RoinujNosde"
 version: "${project.version}-${git.commit.id.describe-short}"
-api-version: 1.21
+api-version: 1.13
 softdepend:
   - "SimpleClans"
   - "Factions"


### PR DESCRIPTION
Isso corrige o problema que nas novas versões não está sendo possível criar kits pois nenhum dado NBT era salvo no arquivo (encantamentos, atributos, etc). Isso ocorria por conta que a api do NBTTAG passou a usar a classe NBT e não NBTItems, tornando vários métodos **deprecated**.