### PR TITLE
Fix 1.21.3+ games kits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.13.2</version>
+            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>


### PR DESCRIPTION
Acima dessa versão tivemos muitas mudanças nas nbt dos itens. A API do nbt-api desatualizada fazia com que os kits não funcionassem mais quando o servidor roda na 1.21.3 ou superior. Atualizar a API já resolveu os problemas e não causa problemas nas versões anteriores.