### PR TITLE
fix: border shrinking during preparation

### DIFF
--- a/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
+++ b/src/main/java/me/roinujnosde/titansbattle/BaseGame.java
@@ -606,11 +606,6 @@ public abstract class BaseGame {
     protected void startPreparation() {
         addTask(new PreparationTimeTask().runTaskLater(plugin, getConfig().getPreparationTime() * 20));
         addTask(new CountdownTitleTask(getCurrentFighters(), getConfig().getPreparationTime()).runTaskTimer(plugin, 0L, 20L));
-        if (getConfig().isWorldBorder()) {
-            long borderInterval = getConfig().getBorderInterval() * 20L;
-            WorldBorder worldBorder = getConfig().getBorderCenter().getWorld().getWorldBorder();
-            addTask(new BorderTask(worldBorder).runTaskTimer(plugin, borderInterval, borderInterval));
-        }
     }
 
     public class LobbyAnnouncementTask extends BukkitRunnable {
@@ -687,6 +682,12 @@ public abstract class BaseGame {
             broadcastKey("preparation_over");
             runCommandsBeforeBattle(getCurrentFighters());
             battle = true;
+            
+            if (getConfig().isWorldBorder()) {
+                long borderInterval = getConfig().getBorderInterval() * 20L;
+                WorldBorder worldBorder = getConfig().getBorderCenter().getWorld().getWorldBorder();
+                addTask(new BorderTask(worldBorder).runTaskTimer(plugin, borderInterval, borderInterval));
+            }
         }
     }
 


### PR DESCRIPTION
Isso faz com que a barreira inicie-se após o fim da preparação e não durante.
![image](https://github.com/user-attachments/assets/920723c4-9395-46aa-a406-57fba9be4c2b)

